### PR TITLE
Fix syntax highlighting for self/cls so they are tokenized as keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix class variables not highlighting or showing in completion list [#46](https://github.com/LuqueDaniel/vscode-language-renpy/issues/46)
 * Fix inherited classes not showing completion parameters [#45](https://github.com/LuqueDaniel/vscode-language-renpy/issues/45)
+* Fix syntax highlighting for self/cls so they are tokenized as keywords [#47](https://github.com/LuqueDaniel/vscode-language-renpy/issues/47)
 
 ## 2.0.2 (2021/10/25)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,8 +133,8 @@ export async function activate(context: ExtensionContext): Promise<any> {
 	);
 	context.subscriptions.push(references);
 
-	const tokenTypes = ['class', 'parameter', 'variable'];
-	const tokenModifiers = ['declaration'];
+	const tokenTypes = ['class', 'parameter', 'variable', 'keyword'];
+	const tokenModifiers = ['declaration', 'defaultLibrary'];
 	const legend = new SemanticTokensLegend(tokenTypes, tokenModifiers);
 
 	// Semantic Token Provider


### PR DESCRIPTION
Fix syntax highlighting for self/cls so they are tokenized as keywords [#47] 

In the Dark theme, they appear as dark blue now. In Dark+ they appear as purple.
![image](https://user-images.githubusercontent.com/12246002/139623086-45bede08-0f83-4c94-b706-80e5e09dd489.png)
