### PR TITLE
folding: improves and simplifies the regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.6 (2022/01/26)
+
+### Changes and improvements
+
+* Improvement and simplification of the regular expression of the folding [#68](https://github.com/LuqueDaniel/vscode-language-renpy/pull/68)
+
+### Fixes
+
+* Fix folding class at the end of init python block [#68](https://github.com/LuqueDaniel/vscode-language-renpy/pull/68)
+
 ## 2.0.5 (2021/12/24)
 
 ### Fixes

--- a/src/folding.ts
+++ b/src/folding.ts
@@ -5,7 +5,7 @@ import { TextDocument, FoldingRange } from "vscode";
 
 export function getFoldingRanges(document: TextDocument): FoldingRange[] {
     let ranges: FoldingRange[] = [];
-    const rxFolding = /^\s*(screen|label|class|layeredimage|def|init)\s+([a-zA-Z0-9_.]+)\((.*)\)\s*:|^\s*(screen|label|class|layeredimage|def|init)\s+([a-zA-Z0-9_.]+)\s*:/;
+    const rxFolding = /^\s*([a-zA-Z]|("|'|`)).*:$/;
     const rxRegionFolding = /^\s*#region[\S]*\s*/;
     const rxendRegionFolding = /^\s*#endregion[\S]*\s*/;
 


### PR DESCRIPTION
Allows folding on lines starting with zero or more whitespace characters followed by one or more characters of the alphabet or quotation marks and ending with a colon.

Fixes #66 #61