### PR TITLE
Allow language-renpy to run in an untrusted workspace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
     "engines": {
         "vscode": "^1.23.0"
     },
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "activationEvents": [
         "*"
     ],


### PR DESCRIPTION
Since new projects are untrusted by default, this extension needs to be able to run in untrusted workspaces, or it won't be applied to Ren'Py files by default.

I don't think there's much of a downside to this, and it should improve the out of the box experience with a fresh Ren'Py install.