### PR TITLE
Replace deprecated `substr` method with `substring`

### DIFF
--- a/src/color.ts
+++ b/src/color.ts
@@ -6,7 +6,7 @@ import { Color, ColorInformation, ColorPresentation, Range, TextDocument, TextEd
 /**
  * Finds all colors in the given document and returns their ranges and color
  * @param document - the TextDocument to search
- * @returns - ColorInformation[] - an array that provides a range and color for each match 
+ * @returns - ColorInformation[] - an array that provides a range and color for each match
  */
 export function getColorInformation(document: TextDocument): ColorInformation[] {
 	// find all colors in the document
@@ -22,9 +22,9 @@ export function getColorInformation(document: TextDocument): ColorInformation[] 
 					const match = matches[idx];
 					let range = new Range(line.lineNumber, text.indexOf(match, start), line.lineNumber, text.indexOf(match, start) + match.length);
 					let color;
-					
+
 					if (match.startsWith('"#') || match.startsWith("'#")) {
-						const quote = match.substr(0, 1);
+						const quote = match.substring(0, 1);
 						if (match.endsWith(quote)) {
 							color = convertHtmlToColor(match);
 						}
@@ -74,7 +74,7 @@ export function getColorPresentations(color: Color, document: TextDocument, rang
 
 	let colorLabel: string = "";
 	if (text.startsWith('"#') || text.startsWith("'#")) {
-		const quote = text.substr(0, 1);
+		const quote = text.substring(0, 1);
 		if (colA === 255 && (text.length === 6 || text.length === 9)) {
 			colorLabel = convertRgbToHex(colR, colG, colB) || "";
 		} else {
@@ -103,7 +103,7 @@ export function getColorPresentations(color: Color, document: TextDocument, rang
  * Search the given text for any color references
  * @remarks
  * This method supports colors in the format `"#rrggbb[aa]"`, `"#rgb[a]"`, `Color((r, g, b[, a]))`, `rgb=(r, g, b)`
- * 
+ *
  * @param text - The text to search
  * @returns A `RegExpMatchArray` containing any color matches
  */
@@ -129,7 +129,7 @@ export function convertRgbToHex(r: number, g: number, b: number, a?: number): st
 	if (a === undefined) {
 		return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
 	} else {
-		return "#" + (256 + r).toString(16).substr(1) + ((1 << 24) + (g << 16) + (b << 8) + a).toString(16).substr(1);
+		return "#" + (256 + r).toString(16).substring(1) + ((1 << 24) + (g << 16) + (b << 8) + a).toString(16).substring(1);
 	}
 }
 
@@ -149,7 +149,7 @@ export function convertColorToRgbTuple(color: Color): string {
 
 /**
  * Returns a Color provider object based on the given html hex color
- * @param hex - The html hex representation 
+ * @param hex - The html hex representation
  * @returns The `Color` provider object
  */
 export function convertHtmlToColor(hex: string) : Color | null {
@@ -227,7 +227,7 @@ export function convertRgbColorToColor(renpyColor: string): Color | null {
 				parseFloat(result[2]),
 				1.0
 				);
-		} 
+		}
 		return null;
 	} catch (error) {
 		return null;

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -17,7 +17,7 @@ import { NavigationData } from "./navigationdata";
 export function getCompletionList(document: TextDocument, position: Position, context: CompletionContext): CompletionItem[] | undefined {
     if (context.triggerKind === CompletionTriggerKind.TriggerCharacter) {
         const line = document.lineAt(position).text;
-        const linePrefix = line.substr(0, position.character);
+        const linePrefix = line.substring(0, position.character);
         if (!NavigationData.positionIsCleanForCompletion(line, position)) {
             return;
         }
@@ -101,7 +101,7 @@ export function getAutoCompleteList(prefix: string, parent: string = "", context
             const category = NavigationData.data.location['define'];
             let audio = Object.keys(category).filter(key => key.startsWith('audio.'));
             for (let key of audio) {
-                newlist.push(new CompletionItem(key.substr(6), CompletionItemKind.Variable));
+                newlist.push(new CompletionItem(key.substring(6), CompletionItemKind.Variable));
             }
         }
         return newlist;
@@ -302,7 +302,7 @@ export function getAutoCompleteKeywords(keyword: string, parent: string, context
                     for (let key in category) {
                         var def_type = NavigationData.gameObjects['define_types'][key];
                         if (def_type) {
-                            
+
                         }
                         newlist.push(new CompletionItem(key, CompletionItemKind.Value));
                     }
@@ -374,7 +374,7 @@ export function getAutoCompleteKeywords(keyword: string, parent: string, context
 }
 
 /**
- * Determines if the given string is a normal integer number 
+ * Determines if the given string is a normal integer number
  * @param str - The string containing a numeric value
  * @returns - True if the given string is a normal integer number
  */
@@ -411,7 +411,7 @@ function getAudioChannels(): string[] {
  * Returns an array containing the `config.layer` definitions
  * @remarks
  * This method looks for a user configured `define config.layers` definition, or else it returns the default config.layers definition
- * 
+ *
  * @returns The config.layer configuration as string[] (e.g, `[ 'master', 'transient', 'screens', 'overlay']`)
  */
 function getLayerConfiguration(quoted: boolean = false): CompletionItem[] | undefined {
@@ -468,7 +468,7 @@ function getDisplayableAutoComplete(quoted: boolean = false): CompletionItem[] {
                 let ci = new CompletionItem(key, CompletionItemKind.Folder);
                 ci.sortText = '1' + key;
                 NavigationData.displayableAutoComplete.push(ci);
-                
+
                 ci = new CompletionItem('"' + key + '"', CompletionItemKind.Folder);
                 ci.sortText = '1' + key;
                 NavigationData.displayableQuotedAutoComplete.push(ci);
@@ -521,7 +521,7 @@ function getCallableAutoComplete(keyword: string): CompletionItem[] | undefined 
         const filtered = Object.keys(callables).filter(key => key.indexOf(prefix) === 0);
         if (filtered) {
             for (let key in filtered) {
-                const label = filtered[key].substr(prefix.length);
+                const label = filtered[key].substring(prefix.length);
                 newlist.push(new CompletionItem(label, CompletionItemKind.Method));
             }
         }
@@ -532,7 +532,7 @@ function getCallableAutoComplete(keyword: string): CompletionItem[] | undefined 
 
 function isInternalClass(keyword: string): boolean {
     const prefix = keyword + '.';
-    const callables = NavigationData.renpyFunctions.internal;    
+    const callables = NavigationData.renpyFunctions.internal;
     if (callables) {
         return Object.keys(callables).some(key => key.indexOf(prefix) === 0);
     }
@@ -549,7 +549,7 @@ function getInternalClassAutoComplete(keyword: string): CompletionItem[] | undef
         const filtered = Object.keys(callables).filter(key => key.indexOf(prefix) === 0);
         if (filtered) {
             for (let key in filtered) {
-                const label = filtered[key].substr(prefix.length);
+                const label = filtered[key].substring(prefix.length);
                 newlist.push(new CompletionItem(label, CompletionItemKind.Method));
             }
         }
@@ -559,7 +559,7 @@ function getInternalClassAutoComplete(keyword: string): CompletionItem[] | undef
 }
 
 function isNamedStore(keyword: string): boolean {
-    const stores = NavigationData.gameObjects['stores'][keyword];    
+    const stores = NavigationData.gameObjects['stores'][keyword];
     if (stores) {
         return true;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -365,7 +365,7 @@ function ExecuteRenpyCompile(): boolean {
 
 		let wf = getWorkspaceFolder();
 		if (wf.endsWith('/game')) {
-			wf = wf.substr(0, wf.length - 5);
+			wf = wf.substring(0, wf.length - 5);
 		}
 		const navData = getNavigationJsonFilepath();
 		//const args = `${wf} compile --json-dump ${navData}`;

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -70,7 +70,7 @@ export function getHoverMarkdownString(locations: Navigation[]) : MarkdownString
 	let contents = new MarkdownString();
 	let index = 0;
 
-	for (let location of locations) 
+	for (let location of locations)
 	{
 		index++;
 		if (index > 1) {
@@ -87,7 +87,7 @@ export function getHoverMarkdownString(locations: Navigation[]) : MarkdownString
 		if (location.filename && location.filename.length > 0 && location.location >= 0) {
 			source = `: ${extractFilename(location.filename)}:${location.location}`;
 		}
-	
+
 		let documentation = location.documentation;
 		let fileContents = "";
 		if (documentation === "" && location.filename !== "" && location.location >= 0) {
@@ -146,7 +146,7 @@ export function getHoverMarkdownString(locations: Navigation[]) : MarkdownString
 			}
 			documentation = formatDocumentationAsMarkdown(documentation);
 			const split = documentation.split('::');
-			if (split.length > 1) {				
+			if (split.length > 1) {
 				contents.appendMarkdown(split[0]);
 				contents.appendMarkdown('\n\n---\n\n');
 				contents.appendCodeblock(split[1]);
@@ -155,7 +155,7 @@ export function getHoverMarkdownString(locations: Navigation[]) : MarkdownString
 			} else {
 				contents.appendMarkdown(split[0]);
 			}
-		}		
+		}
 	}
 
 	return contents;
@@ -196,10 +196,10 @@ export function getDefinitionFromFile(filename: string, line: number): Navigatio
 
 			let docs = "";
 			docs = getPyDocsAtLine(lines, line - 1);
-			
+
 			let args = "";
 			if (text.indexOf('(') > 0) {
-				args = text.substr(text.indexOf('('));
+				args = text.substring(text.indexOf('('));
 				args = args.replace('(self, ', '(');
 				args = args.replace('(self)', '()');
 			}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -60,7 +60,7 @@ export class DataType {
 			this.type = 'store';
 		}
 	}
-	
+
 	checkTypeArray(type: string, typeArray: string[]) {
 		if (typeArray.includes(this.baseclass)) {
 			this.type = type;
@@ -101,9 +101,9 @@ export function getPyDocsAtLine(lines: string[], line: number): string {
 			}
 		} else if (insideComment) {
 			if (text.length === 0 || text.length - text.trimLeft().length >= margin + 3) {
-				lb.push('\n' + text.substr(margin));
+				lb.push('\n' + text.substring(margin));
 			} else {
-				lb.push(text.substr(margin));
+				lb.push(text.substring(margin));
 			}
 		}
 		index++;
@@ -145,9 +145,9 @@ export function getPyDocsFromTextDocumentAtLine(document: TextDocument, line: nu
 			}
 		} else if (insideComment) {
 			if (text.length === 0 || text.length - text.trimLeft().length >= margin + 3) {
-				lb.push('\n' + text.substr(margin));
+				lb.push('\n' + text.substring(margin));
 			} else {
-				lb.push(text.substr(margin));
+				lb.push(text.substring(margin));
 			}
 		}
 		index++;
@@ -204,7 +204,7 @@ export function getArgumentParameterInfo(location: Navigation, line: string, pos
 		} else if (c === ']') {
 			insideBrackets = false;
 		} else if (c === '}') {
-			insideBraces = false; 
+			insideBraces = false;
 		} else if (c === ',' && (insideQuote || insideParens || insideBrackets || insideBraces)) {
 			c = ';';
 		}
@@ -214,11 +214,11 @@ export function getArgumentParameterInfo(location: Navigation, line: string, pos
 	// split the user's args
 	const firstParenIndex = parsed.indexOf('(');
 	let parameterStart = firstParenIndex + 1;
-	const parsedIndex = parsed.substr(parameterStart);
+	const parsedIndex = parsed.substring(parameterStart);
 	const split = parsedIndex.split(',');
 
 	const fragment = parsed.substring(0, position);
-	const fragmentSplit = parsed.substr(fragment.indexOf('(') + 1).split(',');
+	const fragmentSplit = parsed.substring(fragment.indexOf('(') + 1).split(',');
 
 	// calculate the current parameter
 	let currentArgument: number = fragmentSplit.length - 1;
@@ -233,10 +233,10 @@ export function getArgumentParameterInfo(location: Navigation, line: string, pos
 	let args = location.args;
 	if (args) {
 		if (args.startsWith('(')) {
-			args = args.substr(1);
+			args = args.substring(1);
 		}
 		if (args.endsWith(')')) {
-			args = args.substr(0, args.length - 1);
+			args = args.substring(0, args.length - 1);
 		}
 
 		const argsList = args.split(',');
@@ -355,14 +355,14 @@ export function getNamedParameter(strings: string[], named: string): string {
 
 export function stripQuotes(value: string): string {
 	if (value.startsWith('"') && value.endsWith('"')) {
-		value = value.substr(1);
-		value = value.substr(0, value.length - 1);
+		value = value.substring(1);
+		value = value.substring(0, value.length - 1);
 	} else if (value.startsWith("'") && value.endsWith("'")) {
-		value = value.substr(1);
-		value = value.substr(0, value.length - 1);
+		value = value.substring(1);
+		value = value.substring(0, value.length - 1);
 	} else if (value.startsWith("`") && value.endsWith("`")) {
-		value = value.substr(1);
-		value = value.substr(0, value.length - 1);
+		value = value.substring(1);
+		value = value.substring(0, value.length - 1);
 	}
 	return value;
 }

--- a/src/navigationdata.ts
+++ b/src/navigationdata.ts
@@ -26,7 +26,7 @@ export class NavigationData {
 
 	static async init(extensionPath: string) {
 		console.log(`NavigationData init`);
-		
+
 		const data = require(`${extensionPath}/src/renpy.json`);
 		NavigationData.renpyFunctions = data;
 
@@ -36,9 +36,9 @@ export class NavigationData {
 		NavigationData.renpyAutoComplete = [];
 		for (let key in NavigationData.renpyFunctions.renpy) {
 			if (key.charAt(0) === key.charAt(0).toUpperCase()) {
-				NavigationData.renpyAutoComplete.push(new CompletionItem(key.substr(6), CompletionItemKind.Class));
+				NavigationData.renpyAutoComplete.push(new CompletionItem(key.substring(6), CompletionItemKind.Class));
 			} else {
-				NavigationData.renpyAutoComplete.push(new CompletionItem(key.substr(6), CompletionItemKind.Method));
+				NavigationData.renpyAutoComplete.push(new CompletionItem(key.substring(6), CompletionItemKind.Method));
 			}
 		}
 
@@ -52,7 +52,7 @@ export class NavigationData {
 		for (let key in NavigationData.renpyFunctions.internal) {
 			NavigationData.internalAutoComplete.push(new CompletionItem(key, CompletionItemKind.Class));
 			if (key.startsWith('gui.')) {
-				NavigationData.guiAutoComplete.push(new CompletionItem(key.substr(4), CompletionItemKind.Variable));
+				NavigationData.guiAutoComplete.push(new CompletionItem(key.substring(4), CompletionItemKind.Variable));
 			}
 		}
 
@@ -244,13 +244,13 @@ export class NavigationData {
 	 * Determines if the line position is valid for completion or hover events
 	 * @remarks
 	 * This prevents hover/completion from triggering over keywords inside a comment or inside a string literal
-	 * 
+	 *
 	 * @param line The current line in the TextDocument
 	 * @param position The current position in the TextDocument
 	 * @returns `True` if the position is valid for completion or hover events
 	 */
 	static positionIsCleanForCompletion(line: string, position: Position): boolean {
-		const prefix = line.substr(0, position.character);	
+		const prefix = line.substring(0, position.character);
 		// ignore hover/completion if we're in a comment
 		if (prefix.indexOf('#') >= 0) {
 			return false;
@@ -258,7 +258,7 @@ export class NavigationData {
 
 		// ignore completion if we're inside a quoted strings
 		const filtered = NavigationData.filterStringLiterals(line);
-		if (filtered.substr(position.character, 1) === filterCharacter) {
+		if (filtered.substring(position.character, 1) === filterCharacter) {
 			return false;
 		}
 
@@ -268,7 +268,7 @@ export class NavigationData {
 	/**
 	 * Filters out string literals and comments from the given line of text
 	 * @param line The current line in the TextDocument
-	 * @returns A string with any string constants and comments replaced with an unused character 
+	 * @returns A string with any string constants and comments replaced with an unused character
 	 */
 	static filterStringLiterals(line: string): string {
 		let parsed='';
@@ -361,7 +361,7 @@ export class NavigationData {
 	static getClassAutoComplete(keyword: string): CompletionItem[] | undefined {
 		let newlist: CompletionItem[] = [];
 		const prefix = keyword + '.';
-		
+
 		// get any inherited class items
 		const cls = NavigationData.data.location['class'][keyword];
 		if (cls) {
@@ -384,7 +384,7 @@ export class NavigationData {
 			const filtered = Object.keys(callables).filter(key => key.indexOf(prefix) === 0);
 			if (filtered) {
 				for (let key in filtered) {
-					const label = filtered[key].substr(prefix.length);
+					const label = filtered[key].substring(prefix.length);
 					if (!newlist.some(e => e.label === label)) {
 						newlist.push(new CompletionItem(label, CompletionItemKind.Method));
 					}
@@ -767,7 +767,7 @@ export class NavigationData {
 			let append_line = i;
 			let containsKeyword = line.match(rxKeywordList);
 			if (containsKeyword) {
-				// check for unterminated parenthesis for multiline declarations	
+				// check for unterminated parenthesis for multiline declarations
 				let no_string = NavigationData.filterStringLiterals(line);
 				let open_count = (no_string.match(/\(/g)||[]).length;
 				let close_count = (no_string.match(/\)/g)||[]).length;
@@ -958,7 +958,7 @@ export class NavigationData {
 					if (filtered) {
 						for (let key of filtered) {
 							if (key !== char.image) {
-								const attr = key.substr(char.image.length + 1);
+								const attr = key.substring(char.image.length + 1);
 								if (!attributes.includes(attr)) {
 									attributes.push(attr);
 								}
@@ -1007,7 +1007,7 @@ export class NavigationData {
 						if (filtered) {
 							for (let d of filtered) {
 								if (d !== image_key) {
-									const attr = d.substr(image_key.length);
+									const attr = d.substring(image_key.length);
 									if (attr.indexOf('_') > 0) {
 										const split = attr.split('_');
 										if (!attributes.includes(split[0])) {
@@ -1066,7 +1066,7 @@ export function readNavigationJson() {
 		return json;
 	} catch (error) {
 		window.showErrorMessage(`readNavigationJson error: ${error}`);
-	}	
+	}
 }
 
 export function updateNavigationData(type: string, keyword: string, filename: string, line: number) {

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -28,7 +28,7 @@ export function getDocumentSymbols(document: TextDocument): DocumentSymbol[] | u
                 if (category[key].filename === documentFilename) {
                     const childRange = new Range(category[key].location - 1, 0, category[key].location - 1, 0);
                     let classParent = new DocumentSymbol(key, `:${category[key].location}`, getDocumentSymbolKind(type, true), childRange, childRange);
-                    if (type === 'class') {                                        
+                    if (type === 'class') {
                         getClassDocumentSymbols(classParent, key);
                     }
                     parentSymbol.children.push(classParent);
@@ -37,7 +37,7 @@ export function getDocumentSymbols(document: TextDocument): DocumentSymbol[] | u
                 if (category[key][0] === documentFilename) {
                     const childRange = new Range(category[key][1] - 1, 0, category[key][1] - 1, 0);
                     let classParent = new DocumentSymbol(key, `:${category[key][1]}`, getDocumentSymbolKind(type, true), childRange, childRange);
-                    if (type === 'class') {                                        
+                    if (type === 'class') {
                         getClassDocumentSymbols(classParent, key);
                     }
                     parentSymbol.children.push(classParent);
@@ -120,7 +120,7 @@ function getClassDocumentSymbols(classParent: DocumentSymbol, key: string) {
         const filtered = Object.keys(callables).filter(k => k.indexOf(key + '.') === 0);
         if (filtered) {
             for (let callable of filtered) {
-                const label = callable.substr(key.length + 1);
+                const label = callable.substring(key.length + 1);
                 const line = callables[callable][1];
                 const childRange = new Range(line - 1, 0, line - 1, 0);
                 classParent.children.push(
@@ -155,7 +155,7 @@ function getStoreDocumentSymbols(classParent: DocumentSymbol, key: string) {
         const filtered = Object.keys(callables).filter(k => k.indexOf(key + '.') === 0);
         if (filtered) {
             for (let callable of filtered) {
-                const label = callable.substr(key.length + 1);
+                const label = callable.substring(key.length + 1);
                 const line = callables[callable][1];
                 const childRange = new Range(line - 1, 0, line - 1, 0);
                 classParent.children.push(

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -22,7 +22,7 @@ export function getSemanticTokens(document: TextDocument, legend: SemanticTokens
     let parent_defaults: { [key: string]: Navigation } = {};
     let indent_level = 0;
     let append_line = 0;
-    
+
     for (let i = 0; i < document.lineCount; ++i) {
         let line = document.lineAt(i).text;
 
@@ -92,7 +92,7 @@ export function getSemanticTokens(document: TextDocument, legend: SemanticTokens
                     } else {
                         tokensBuilder.push(range, 'parameter', ['declaration']);
                     }
-                    parent_args.push(line.substr(start + offset, length - offset));
+                    parent_args.push(line.substring(start + offset, length - offset));
                     parent_defaults[m.substring(offset, length)] = new Navigation("parameter", m.substring(offset, length), filename, i + 1, "", m.trim(), "", start + offset);
                     // create a Navigation dictionary entry for this token range
                     const key = rangeAsString(filename, range);
@@ -252,7 +252,7 @@ export function getSemanticTokens(document: TextDocument, legend: SemanticTokens
                             const split = matches[2].split(',');
                             for (let m of split) {
                                 const offset = m.length - m.trimLeft().length;
-                                if (parent_args.includes(m.substr(offset))) {
+                                if (parent_args.includes(m.substring(offset))) {
                                     continue;
                                 }
 
@@ -261,11 +261,11 @@ export function getSemanticTokens(document: TextDocument, legend: SemanticTokens
                                 if (matches[1] === 'global') {
                                     source = 'global variable';
                                 }
-                                if (!parent_local.some(e => e[0] === m.substr(offset))) {
+                                if (!parent_local.some(e => e[0] === m.substring(offset))) {
                                     if (matches[1] === 'global') {
-                                        parent_local.push([m.substr(offset), 'g']);
+                                        parent_local.push([m.substring(offset), 'g']);
                                     } else {
-                                        parent_local.push([m.substr(offset), 'v']);
+                                        parent_local.push([m.substring(offset), 'v']);
                                     }
                                 } else {
                                     continue;
@@ -282,13 +282,13 @@ export function getSemanticTokens(document: TextDocument, legend: SemanticTokens
                                 } else {
                                     docs = `${parent_type} ${parent}()\n    ${line.trim()}`;
                                 }
-                                const navigation = new Navigation(source, m.substr(offset), filename, i + 1, docs, "", parent_type, start + offset);
+                                const navigation = new Navigation(source, m.substring(offset), filename, i + 1, docs, "", parent_type, start + offset);
                                 NavigationData.gameObjects['semantic'][key] = navigation;
-                                parent_defaults[`${parent_type}.${parent}.${m.substr(offset)}`] = navigation;
+                                parent_defaults[`${parent_type}.${parent}.${m.substring(offset)}`] = navigation;
 
                                 if (parent_type === 'store') {
                                     const pKey = `store.${parent}`;
-                                    const objKey = `${parent}.${m.substr(offset)}`;
+                                    const objKey = `${parent}.${m.substring(offset)}`;
                                     const navigation = new Navigation(source, objKey, filename, i + 1, docs, "", parent_type, start + offset);
 
                                     if (NavigationData.gameObjects['fields'][pKey] === undefined) {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -5,8 +5,8 @@ import { workspace } from "vscode";
 import * as fs from 'fs';
 
 /**
- * Returns the filename.extension for the given fully qualified path 
- * @param str - The full path and filename of the file 
+ * Returns the filename.extension for the given fully qualified path
+ * @param str - The full path and filename of the file
  * @returns The filename.ext of the filepath
  */
 export function extractFilename(str: string) {
@@ -18,8 +18,8 @@ export function extractFilename(str: string) {
 }
 
 /**
- * Returns the filename without the path and extension for the given fully qualified path 
- * @param str - The full path and filename of the file 
+ * Returns the filename without the path and extension for the given fully qualified path
+ * @param str - The full path and filename of the file
  * @returns The filename of the filepath
  */
 export function extractFilenameWithoutExtension(str: string) {
@@ -35,7 +35,7 @@ export function extractFilenameWithoutExtension(str: string) {
 
 /**
  * Strips the workspace path from the file, leaving the path relative to the workspace plus filename (e.g., `game/script.rpy`)
- * @param str - The full path and filename of the file 
+ * @param str - The full path and filename of the file
  * @returns The filename of the filepath (e.g., `game/script.rpy`)
  */
 export function stripWorkspaceFromFile(str: string) {
@@ -43,11 +43,11 @@ export function stripWorkspaceFromFile(str: string) {
 
 	let filename = cleanUpPath(str);
 	if (filename.toLowerCase().startsWith(wf.toLowerCase())) {
-		filename = filename.substr(wf.length + 1);
+		filename = filename.substring(wf.length + 1);
 	}
 
 	while (filename.startsWith('/')) {
-		filename = filename.substr(1);
+		filename = filename.substring(1);
 	}
 	return filename;
 }
@@ -69,13 +69,13 @@ export function getWorkspaceFolder() {
  * Gets the full path and filename of the file with invalid characters removed
  * @remarks
  * This removes the leading `/` character that appears before the path on Windows systems (e.g., `/c:/user/Documents/renpy/game/script.rpy`)
- * @param path - The full path and filename of the file 
+ * @param path - The full path and filename of the file
  * @returns The full path and filename of the file with invalid characters removed
  */
 export function cleanUpPath(path: string): string {
-	if (path.startsWith('/') && path.substr(2, 2) === ":/") {
+	if (path.startsWith('/') && path.substring(2, 2) === ":/") {
 		// windows is reporting the path as "/c:/xxx"
-		path = path.substr(1);
+		path = path.substring(1);
 	}
 	return path;
 }


### PR DESCRIPTION
Previously, both `substr` and `substring` methods were used interchangeably. From what I've tested both methods work the same and return the same result. Since `substr` is deprecated I've replaced it with `substring`.