### PR TITLE
Improves detection of `label`, `transform`, `screen`, `def` and `class` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## 2.0.7 ()
 
+### Changes and improvements
+
+* Improved detection of `label`, `transform`, `screen`, `def` and `class` in some special cases.
+* Update dev dependencies.
+
 ### Fixes
 
-* Fixes `Visual Studio Code.edit.py` opening files containing spaces in the path [#79](https://github.com/LuqueDaniel/vscode-language-renpy/issues/79)
+* Fix `Visual Studio Code.edit.py` opening files containing spaces in the path [#79](https://github.com/LuqueDaniel/vscode-language-renpy/issues/79)
 
 ## 2.0.6 (2022/02/22)
 

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -9,7 +9,7 @@ import { stripWorkspaceFromFile } from "./workspace";
 export function getSemanticTokens(document: TextDocument, legend: SemanticTokensLegend): SemanticTokens {
     const tokensBuilder = new SemanticTokensBuilder(legend);
     const rxKeywordList = /\s*(screen|label|transform|def|class)\s+/;
-    const rxParameterList = /\s*(screen|label|transform|def|class)\s+([a-zA-Z0-9_.]+)\((.*)\):|\s*(label)\s+([a-zA-Z0-9_.]+)\s*:|^(init)\s+([-\d]+\s+)*python\s+in\s+(\w+):|^(python)\s+early\s+in\s+(\w+):|\s*(class)\s+([a-zA-Z0-9_]+)\s*/s;
+    const rxParameterList = /\s*(screen|label|transform|def|class)\s+([a-zA-Z_]\w+)\s*\((.*)\)\s*:|\s*(label)\s+([a-zA-Z0-9_.]+)\s*:|^(init)\s+([-\d]+\s+)*python\s+in\s+(\w+):|^(python)\s+early\s+in\s+(\w+):|\s*(class)\s+([a-zA-Z0-9_]+)\s*/s;
     const rxVariableDefines = /^\s*(default|define)\s+([a-zA-Z]+[a-zA-Z0-9_]*)\s*=\s*(.*)/;
     const rxPersistentDefines = /^\s*(default|define)\s+persistent\.([a-zA-Z]+[a-zA-Z0-9_]*)\s*=\s*(.*)/;
     const filename = stripWorkspaceFromFile(document.uri.path);


### PR DESCRIPTION
Now detect these keywords if there are spaces before and/or after the parenthesis.