### PR TITLE
fix: Properly remove the leading slash

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -73,7 +73,7 @@ export function getWorkspaceFolder() {
  * @returns The full path and filename of the file with invalid characters removed
  */
 export function cleanUpPath(path: string): string {
-	if (path.startsWith('/') && path.substring(2, 2) === ":/") {
+	if (path.startsWith('/') && path.startsWith(":/", 2)) {
 		// windows is reporting the path as "/c:/xxx"
 		path = path.substring(1);
 	}


### PR DESCRIPTION
.substring(2, 2) returns ''

This function expects a start and end index, so start and end is both 2 in this case.

To fix this I used startsWith with to offset parameter. This checks if the path contains ":/" at the correct location.