### PR TITLE
Small fixes in python block and new indenting rules

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -30,10 +30,27 @@
         ["\"\"\"", "\"\"\""]
     ],
     "folding": {
+        "offSide": true,
         "markers": {
-          "start": "^#region",
-          "end": "^#endregion"
+          "start": "^\\s*#\\s*region\\b",
+          "end": "^\\s*#\\s*endregion\\b"
+        }
+    },
+    "onEnterRules": [
+        //Renpy keywords
+        {
+            "beforeText": "^\\s*\\b(?:label|menu|python|init|screen|transform)\\b.*:\\s*$",
+            "action": { "indent": "indent" }
         },
-        "offSide": true
-    }
+        //Python keywords available in renpy code
+        {
+            "beforeText": "^\\s*\\b(?:for|if|elif|else|while)\\b.*:\\s*$",
+            "action": { "indent": "indent" }
+        },
+        //For menu's
+        {
+            "beforeText": "^\\s+(?:\".*?\"|\\'.*?\\')\\s*:\\s*$",
+            "action": { "indent": "indent" }
+        }
+    ]
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,56 +1,56 @@
 {
-    "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "#"
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "#"
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "`", "close": "`", "notIn": ["string"] },
+    { "open": "\"\"\"", "close": "\"\"\"", "notIn": ["string"] }
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"],
+    ["`", "`"],
+    ["\"\"\"", "\"\"\""]
+  ],
+  "folding": {
+    "offSide": true,
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  },
+  "onEnterRules": [
+    //Renpy keywords
+    {
+      "beforeText": "^\\s*\\b(?:label|menu|python|init|screen|transform)\\b.*:\\s*$",
+      "action": { "indent": "indent" }
     },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
-    // symbols that are auto closed when typing
-    "autoClosingPairs": [
-		{ "open": "{", "close": "}" },
-		{ "open": "[", "close": "]" },
-		{ "open": "(", "close": ")" },
-		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "'", "close": "'", "notIn": ["string"] },
-        { "open": "`", "close": "`", "notIn": ["string"] },
-        { "open": "\"\"\"", "close": "\"\"\"", "notIn": ["string"] }
-    ],
-    // symbols that that can be used to surround a selection
-    "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"],
-        ["`", "`"],
-        ["\"\"\"", "\"\"\""]
-    ],
-    "folding": {
-        "offSide": true,
-        "markers": {
-          "start": "^\\s*#\\s*region\\b",
-          "end": "^\\s*#\\s*endregion\\b"
-        }
+    //Python keywords available in renpy code
+    {
+      "beforeText": "^\\s*\\b(?:for|if|elif|else|while)\\b.*:\\s*$",
+      "action": { "indent": "indent" }
     },
-    "onEnterRules": [
-        //Renpy keywords
-        {
-            "beforeText": "^\\s*\\b(?:label|menu|python|init|screen|transform)\\b.*:\\s*$",
-            "action": { "indent": "indent" }
-        },
-        //Python keywords available in renpy code
-        {
-            "beforeText": "^\\s*\\b(?:for|if|elif|else|while)\\b.*:\\s*$",
-            "action": { "indent": "indent" }
-        },
-        //For menu's
-        {
-            "beforeText": "^\\s+(?:\".*?\"|\\'.*?\\')\\s*:\\s*$",
-            "action": { "indent": "indent" }
-        }
-    ]
+    //For menu's
+    {
+      "beforeText": "^\\s+(?:\".*?\"|\\'.*?\\')\\s*:\\s*$",
+      "action": { "indent": "indent" }
+    }
+  ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,16 +61,6 @@ let myStatusBarItem: StatusBarItem;
 export async function activate(context: ExtensionContext): Promise<any> {
     console.log("Ren'Py extension activated");
 
-    languages.setLanguageConfiguration("renpy", {
-        onEnterRules: [
-            {
-                // indentation for Ren'Py and Python blocks
-                beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|label|menu|init|\":|\':|python|).*?:\s*$/,
-                action: { indentAction: IndentAction.Indent },
-            },
-        ],
-    });
-
     const filepath = getNavigationJsonFilepath();
     const jsonFileExists = fs.existsSync(filepath);
     if (!jsonFileExists) {

--- a/syntaxes/renpy.tmLanguage_2.json
+++ b/syntaxes/renpy.tmLanguage_2.json
@@ -18,7 +18,7 @@
           "comment": "Renpy python block",
           "contentName": "meta.embedded.block.python",
 
-          "begin": "(^[ \\t]+)?\\b(?:(init) (?:(-)?(\\d*) )?)?(python)([\\w \\t]*)(:)",
+          "begin": "(^[ \\t]+)?(?:\\b(init)\\b\\s+(?:(-)?(\\d*)\\s+)?)?\\b(python)\\b(.*?)(:)",
           "beginCaptures": {
             "1": {
               "name": "punctuation.whitespace.embedded.leading.python"
@@ -36,13 +36,14 @@
               "name": "keyword.renpy"
             },
             "6": {
-              "name": "meta.embedded.block.python.options",
+              "name": "meta.python.block.arguments.renpy",
 
               "patterns": [
                 {
                   "comment": "in statement",
-                  "match": "(?: (in) ([a-zA-Z_]\\w+))",
-                  "captures": {
+                  "match": "(?:\\s*(in)\\s*([a-zA-Z_]\\w*)\\b)",
+                  "captures":
+                  {
                     "1": {
                       "name": "keyword.renpy"
                     },

--- a/syntaxes/renpy.tmLanguage_2.json
+++ b/syntaxes/renpy.tmLanguage_2.json
@@ -42,8 +42,7 @@
                 {
                   "comment": "in statement",
                   "match": "(?:\\s*(in)\\s*([a-zA-Z_]\\w*)\\b)",
-                  "captures":
-                  {
+                  "captures": {
                     "1": {
                       "name": "keyword.renpy"
                     },


### PR DESCRIPTION
* Store should be allowed to have single character names
* Allow multiple (tabs and) spaces between words
* Make sure we catch all characters between 'python' and ':'
* Don't use meta.embedded for the arguments since this will change the language and prevent indent

* Moved them to the language config to keep them where they belong
* Removed python keywords that are not available in Renpy code
* Split rules to get a more clear overview
* Special case for when in menu's