### PR TITLE
fix: Allow double underscore in variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.10 (2022/05/21)
+
+### Fixes
+
+* Allow double underscore in variable names [#123](https://github.com/LuqueDaniel/vscode-language-renpy/pull/123) (fix issue [#122](https://github.com/LuqueDaniel/vscode-language-renpy/issues/122))
+
+### Other changes
+
+* Reserved variable names now show as warnings instead of errors
+
 ## 2.0.9 (2022/05/02)
 
 ### Fixes

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -181,7 +181,7 @@ function checkComparisonVsAssignment(diagnostics: Diagnostic[], line: string, li
 }
 
 function checkReservedRenpyNames(diagnostics: Diagnostic[], line: string, lineIndex: number) {
-    // check for default/define variables that are Python reserved names
+    // check for default/define variables that are Ren'Py reserved names
     let matches;
     while ((matches = rxReservedVariableCheck.exec(line)) !== null) {
         const offset = matches.index + matches[0].indexOf(matches[2]);
@@ -197,7 +197,7 @@ function checkReservedPythonNames(diagnostics: Diagnostic[], line: string, lineI
     while ((matches = rxReservedPythonCheck.exec(line)) !== null) {
         const offset = matches.index + matches[0].indexOf(matches[2]);
         const range = new Range(lineIndex, offset, lineIndex, offset + matches[2].length);
-        const diagnostic = new Diagnostic(range, `"${matches[2]}" is a Python reserved name, type, or function. Using it as a variable can lead to obscure problems or unpredictable behavior.`, DiagnosticSeverity.Warning);
+        const diagnostic = new Diagnostic(range, `"${matches[2]}": is a Python reserved name, type, or function. Using it as a variable can lead to obscure problems or unpredictable behavior.`, DiagnosticSeverity.Warning);
         diagnostics.push(diagnostic);
     }
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -175,7 +175,7 @@ function checkComparisonVsAssignment(diagnostics: Diagnostic[], line: string, li
     while ((matches = rsComparisonCheck.exec(line)) !== null) {
         const offset = matches.index + matches[0].indexOf(matches[3]);
         const range = new Range(lineIndex, offset, lineIndex, offset + matches[3].length);
-        const diagnostic = new Diagnostic(range, `"=" is the equality operator. Use "==" for comparison.`, DiagnosticSeverity.Warning);
+        const diagnostic = new Diagnostic(range, `"=" is the assignment operator. Use "==" for comparison.`, DiagnosticSeverity.Warning);
         diagnostics.push(diagnostic);
     }
 }


### PR DESCRIPTION
* rxVariableCheck now allows the use of underscore in the name
* Added rxReservedVariableCheck that specifically tests for single underscore
* Added checkReservedRenpyNames function that pushes a warning if a single underscore variable was found
* Changed checkReservedPythonNames to result in a warning as the config suggests 'if (config.warnOnReservedVariableNames)'