### PR TITLE
reg: version 2.0.10 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.10 (2022/05/24)
+
+### Fixes
+
+* Allow double underscore in variable names [#123](https://github.com/LuqueDaniel/vscode-language-renpy/pull/123) (fix issue [#122](https://github.com/LuqueDaniel/vscode-language-renpy/issues/122))
+
+### Other changes
+
+* Reserved variable names now show as warnings instead of errors
+
 ## 2.0.9 (2022/05/02)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "languague-renpy",
   "displayName": "Ren'Py Language",
   "description": "Adds rich support for the Ren'Py programming language to Visual Studio Code.",
-  "version": "2.0.8",
+  "version": "2.0.10",
   "publisher": "LuqueDaniel",
   "license": "MIT",
   "homepage": "https://github.com/LuqueDaniel/vscode-language-renpy",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -44,7 +44,8 @@ const rxReservedPythonCheck =
 const rxObsoleteCheck =
     /[\s(=]+(LiveCrop|LiveComposite|Tooltip|im\.Rotozoom|im\.ImageBase|im\.ramp|im\.Map|im\.Flip|im\.math|im\.expands_bounds|im\.threading|im\.zipfile|im\.Recolor|im\.Color|im\.io|im\.Alpha|im\.Data|im\.Image|im\.Twocolor|im\.MatrixColor|im\.free_memory|im\.Tile|im\.FactorScale|im\.Sepia|im\.Crop|im\.AlphaMask|im\.Blur|im\.tobytes|im\.matrix|im\.Grayscale|ui\.add|ui\.bar|ui\.imagebutton|ui\.input|ui\.key|ui\.label|ui\.null|ui\.text|ui\.textbutton|ui\.timer|ui\.vbar|ui\.hotspot|ui\.hotbar|ui\.spritemanager|ui\.button|ui\.frame|ui\.transform|ui\.window|ui\.drag|ui\.fixed|ui\.grid|ui\.hbox|ui\.side|ui\.vbox|ui\.imagemap|ui\.draggroup)[^a-zA-Z]/g;
 
-const rxVariableCheck = /^\s*(default|define)\s+([^a-zA-Z\s][a-zA-Z0-9_]*)\s+=/g;
+const rxVariableCheck = /^\s*(default|define)\s+([^a-zA-Z\s_][a-zA-Z0-9_]*)\s+=/g;
+const rxReservedVariableCheck = /\s*(default|define)\s+(_[a-zA-Z0-9]*)\s+=/g;
 const rxPersistentDefines = /^\s*(default|define)\s+persistent\.([a-zA-Z]+[a-zA-Z0-9_]*)\s*=\s*(.*$)/g;
 const rxPersistentCheck = /\s+persistent\.(\w+)[^a-zA-Z]/g;
 const rxStoreCheck = /\s+store\.(\w+)[^a-zA-Z_]?/g;
@@ -147,6 +148,7 @@ export function refreshDiagnostics(doc: TextDocument, diagnosticCollection: Diag
         }
 
         if (config.warnOnReservedVariableNames) {
+            checkReservedRenpyNames(diagnostics, line, lineIndex);
             checkReservedPythonNames(diagnostics, line, lineIndex);
         }
 
@@ -204,7 +206,18 @@ function checkComparisonVsAssignment(diagnostics: Diagnostic[], line: string, li
     while ((matches = rsComparisonCheck.exec(line)) !== null) {
         const offset = matches.index + matches[0].indexOf(matches[3]);
         const range = new Range(lineIndex, offset, lineIndex, offset + matches[3].length);
-        const diagnostic = new Diagnostic(range, `"=" is the equality operator. Use "==" for comparison.`, DiagnosticSeverity.Warning);
+        const diagnostic = new Diagnostic(range, `"=" is the assignment operator. Use "==" for comparison.`, DiagnosticSeverity.Warning);
+        diagnostics.push(diagnostic);
+    }
+}
+
+function checkReservedRenpyNames(diagnostics: Diagnostic[], line: string, lineIndex: number) {
+    // check for default/define variables that are Ren'Py reserved names
+    let matches;
+    while ((matches = rxReservedVariableCheck.exec(line)) !== null) {
+        const offset = matches.index + matches[0].indexOf(matches[2]);
+        const range = new Range(lineIndex, offset, lineIndex, offset + matches[2].length);
+        const diagnostic = new Diagnostic(range, `"${matches[2]}": Variables may not begin with a single underscore '_' as Ren'Py reserves such variables for its own purposes.`, DiagnosticSeverity.Warning);
         diagnostics.push(diagnostic);
     }
 }
@@ -215,7 +228,7 @@ function checkReservedPythonNames(diagnostics: Diagnostic[], line: string, lineI
     while ((matches = rxReservedPythonCheck.exec(line)) !== null) {
         const offset = matches.index + matches[0].indexOf(matches[2]);
         const range = new Range(lineIndex, offset, lineIndex, offset + matches[2].length);
-        const diagnostic = new Diagnostic(range, `"${matches[2]}" is a Python reserved name, type, or function. Using it as a variable can lead to obscure problems or unpredictable behavior.`, DiagnosticSeverity.Error);
+        const diagnostic = new Diagnostic(range, `"${matches[2]}": is a Python reserved name, type, or function. Using it as a variable can lead to obscure problems or unpredictable behavior.`, DiagnosticSeverity.Warning);
         diagnostics.push(diagnostic);
     }
 }
@@ -238,11 +251,7 @@ function checkInvalidVariableNames(diagnostics: Diagnostic[], line: string, line
         if (!renpyStore.includes(matches[2])) {
             const offset = matches.index + matches[0].indexOf(matches[2]);
             const range = new Range(lineIndex, offset, lineIndex, offset + matches[2].length);
-            const diagnostic = new Diagnostic(
-                range,
-                `"${matches[2]}": Variables must begin with a letter (and may contain numbers, letters, or underscores). Variables may not begin with '_' as Ren'Py reserves such variables for its own purposes.`,
-                severity
-            );
+            const diagnostic = new Diagnostic(range, `"${matches[2]}": Variables must begin with a letter (and may contain numbers, letters, or underscores).`, severity);
             diagnostics.push(diagnostic);
         }
     }


### PR DESCRIPTION
From 4504e62 and 32409ed

* rxVariableCheck now allows the use of underscore in the name
* Added rxReservedVariableCheck that specifically tests for single
  underscore
* Added checkReservedRenpyNames function that pushes a warning if a
  single underscore variable was found
* Changed checkReservedPythonNames to result in a warning as the config
  suggests 'if (config.warnOnReservedVariableNames)'
* Update CHANGELOG.md