### PR TITLE
Updates publish workflow to support pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,30 +7,38 @@ on:
     tags:
       - "v*"
 
+env:
+  IS_PRE_RELEASE: ${{ endsWith(github.ref_name, 'pre-release') }}
+
 jobs:
-  deploy:
+  publish:
+    name: Publish Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm ci
-      - name: Publish to Open VSX Registry
-        id: publishToOpenVSX
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.OVSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
+        id: publishToVSM
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          preRelease: ${{ env.IS_PRE_RELEASE }}
+      - name: Publish to Open VSX Registry
+        if: ${{ ! fromJSON(env.IS_PRE_RELEASE) }}
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OVSX_TOKEN }}
+          registryUrl: https://open-vsx.org
+          extensionFile: ${{ steps.publishToVSM.outputs.vsixPath }}
       - name: Create draft GitHub Release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
+          preRelease: ${{ env.IS_PRE_RELEASE }}
           generateReleaseNotes: true
-          artifacts: "${{ steps.publishToOpenVSX.outputs.vsixPath }}"
+          artifacts: "${{ steps.publishToVSM.outputs.vsixPath }}"

--- a/Contributing.md
+++ b/Contributing.md
@@ -23,11 +23,20 @@ If you want to add new features, please make sure to discuss it in an issue.
 3. Now select the folder of your newly cloned project. (Eg. `../vscode-language-renpy/`)
 
 <details><summary>If done correctly your folder view should look like this.</summary>
-   
+
 ![image](https://user-images.githubusercontent.com/60387522/176013833-e5d39ebc-0b13-4a6f-b10c-c2e3b4f68f67.png)
-   
+
 </details>
 
 4. Install the recommended extensions (A popup should appear). This will make sure you get the best developer experience in our workflow and it will format the code as intended.
 5. Make your changes and submit a pull request
 6. Happy coding! 🚀
+
+## Additional Information
+
+### Extension Versions
+
+There are two versions: **release** and **pre-release**. Because [VS Code only supports](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions) `major.minor.patch` and not the additional [semver](https://semver.org/) labels for pre-releases, to know if a version is a pre-release or final release, check its `minor` number:
+
+* `major.EVEN_NUMBER.patch` for final releases.
+* `major.ODD_NUMBER.patch` for pre-releases.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Snippets"
   ],
   "engines": {
-    "vscode": "^1.50.0"
+    "vscode": "^1.63.0"
   },
   "capabilities": {
     "untrustedWorkspaces": {
@@ -180,7 +180,7 @@
     "lint": "eslint -c .eslintrc.json --ext .ts ./src/"
   },
   "devDependencies": {
-    "@types/vscode": "^1.50.0",
+    "@types/vscode": "^1.63.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.0.3",
     "@typescript-eslint/eslint-plugin": "^5.25.0",


### PR DESCRIPTION
* Updated GitHub actions to the latest major version.
* Now the releases will be published first in Visual Studio Marketplace because Open VSX doesn't support pre-releases.
* If the git tag ends in `pre-release`: a pre-release version will be published on Visual Studio Marketplace, it will not be published on Open VSX, and the release created on GitHub will be pre-release.
* Updated `Contributing.md` to explain versioning.