### PR TITLE
Change `warnOnInvalidVariableNames` config to boolean

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "files.exclude": {
-    "**/*.rpyc": true
+    "**/*.rpyc": true,
+    "**/*.rpa": true,
+    "**/*.rpymc": true,
+    "**/cache/": true
   },
   "search.exclude": {
     "out": true, // set this to false to include "out" folder in search results

--- a/package.json
+++ b/package.json
@@ -136,19 +136,9 @@
             "description": "Enable reserved variable warnings. If checked (true), variables will be marked with an error in the editor if they are in the list of names reserved by Python."
           },
           "renpy.warnOnInvalidVariableNames": {
-            "type": "string",
-            "default": "Error",
-            "enum": [
-              "Error",
-              "Warning",
-              "Disabled"
-            ],
-            "enumDescriptions": [
-              "Display invalid variable name issues as errors",
-              "Display invalid variable name issues as warnings",
-              "Ignore invalid variable name issues"
-            ],
-            "description": "Enable invalid variable warnings. Variables must begin with a letter or number. They may contain a '_' but may not begin with '_'. If set to Warning or Error, variables will be flagged in the editor if they do not meet Ren'Py's specifications."
+            "type": "boolean",
+            "default": true,
+            "description": "Enable invalid variable errors. Variables must begin with a letter or number. They may contain a '_' but may not begin with '_'. If set to true, variables will be flagged in the editor if they do not meet Ren'Py's specifications."
           },
           "renpy.warnOnIndentationAndSpacingIssues": {
             "type": "string",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -138,13 +138,8 @@ export function refreshDiagnostics(doc: TextDocument, diagnosticCollection: Diag
             }
         }
 
-        const checkVariables: string = config.warnOnInvalidVariableNames;
-        if (checkVariables.toLowerCase() !== "disabled") {
-            let severity = DiagnosticSeverity.Error;
-            if (checkVariables.toLowerCase() === "warning") {
-                severity = DiagnosticSeverity.Warning;
-            }
-            checkInvalidVariableNames(diagnostics, line, lineIndex, severity);
+        if (config.warnOnInvalidVariableNames) {
+            checkInvalidVariableNames(diagnostics, line, lineIndex);
         }
 
         if (config.warnOnReservedVariableNames) {
@@ -243,7 +238,7 @@ function checkStrayDollarSigns(diagnostics: Diagnostic[], line: string, lineInde
     }
 }
 
-function checkInvalidVariableNames(diagnostics: Diagnostic[], line: string, lineIndex: number, severity: DiagnosticSeverity) {
+function checkInvalidVariableNames(diagnostics: Diagnostic[], line: string, lineIndex: number) {
     // check line for invalid define/default variable names
     // Variables must begin with a letter or number, and may not begin with '_'
     let matches;
@@ -251,7 +246,7 @@ function checkInvalidVariableNames(diagnostics: Diagnostic[], line: string, line
         if (!renpyStore.includes(matches[2])) {
             const offset = matches.index + matches[0].indexOf(matches[2]);
             const range = new Range(lineIndex, offset, lineIndex, offset + matches[2].length);
-            const diagnostic = new Diagnostic(range, `"${matches[2]}": Variables must begin with a letter (and may contain numbers, letters, or underscores).`, severity);
+            const diagnostic = new Diagnostic(range, `"${matches[2]}": Variables must begin with a letter (and may contain numbers, letters, or underscores).`, DiagnosticSeverity.Error);
             diagnostics.push(diagnostic);
         }
     }


### PR DESCRIPTION
As the flagged variable name is not valid for Ren'Py. If the `warnOnInvalidVariableNames` config is enabled it will be displayed as an error.

Closes #124