### PR TITLE
Fix scene statement highlighting

### DIFF
--- a/syntaxes/renpy.tmLanguage.json
+++ b/syntaxes/renpy.tmLanguage.json
@@ -263,11 +263,15 @@
           "beginCaptures": {
             "1": { "name": "keyword.renpy" }
           },
-          "end": "(?=\\b(at|with)\\b|#)|$",
+          "end": "(?=\\b(at|as|behind|onlayer|expression|with|zorder)\\b|#)|$",
           "patterns": [{ "include": "#strings" }, { "match": "\\b(?:[a-zA-Z_0-9]*)\\b[ \\t]*", "name": "entity.name.type.image.renpy" }]
         },
         { "include": "#at" },
-        { "include": "#with" }
+        { "include": "#as" },
+        { "include": "#with" },
+        { "include": "#behind" },
+        { "include": "#onlayer" },
+        { "include": "#zorder" }
       ]
     },
 

--- a/syntaxes/renpy.tmLanguage.json
+++ b/syntaxes/renpy.tmLanguage.json
@@ -264,7 +264,7 @@
             "1": { "name": "keyword.renpy" }
           },
           "end": "(?=\\b(at|with)\\b|#)|$",
-          "patterns": [{ "match": "\\b(?:[a-zA-Z_0-9]*)\\b[ \\t]*", "name": "entity.name.type.image.renpy" }]
+          "patterns": [{ "include": "#strings" }, { "match": "\\b(?:[a-zA-Z_0-9]*)\\b[ \\t]*", "name": "entity.name.type.image.renpy" }]
         },
         { "include": "#at" },
         { "include": "#with" }


### PR DESCRIPTION
This fixes #182 as well as adds missing patterns to the statement. I checked the source code, renpy allows to use all `show` statement parameters with `scene`, like `as`, `onlayer`, etc. That means the code for `show` and `scene` is basically the same, so maybe you can find a way to reuse some bits, but maybe it's best to keep them separate in case renpy changes how it handles `scene`.