### PR TITLE
Basic screen lang

### DIFF
--- a/examples/unit_test.rpy
+++ b/examples/unit_test.rpy
@@ -3793,6 +3793,25 @@
 #endregion Python and Ren'Py
 
 #region other
+    screen extract_dialogue:
+
+        frame:
+            style_group "l"
+            style "l_root"
+
+            window:
+
+                has vbox
+
+                label _("Extract Dialogue: [project.current.display_name!q]"):
+                    test
+
+                add HALF_SPACER
+
+                frame:
+                    style "l_indent"
+                    xfill True
+
     # Return Statement
     label main_menu:
         return "no_unlock"

--- a/src/tokenizer/debug-decorator.ts
+++ b/src/tokenizer/debug-decorator.ts
@@ -277,6 +277,7 @@ ${(decoration.hoverMessage as MarkdownString).value}`);
             case KeywordTokenType.Image:
             case KeywordTokenType.LayeredImage:
             case KeywordTokenType.Window:
+            case KeywordTokenType.Frame:
             case KeywordTokenType.Transform:
             case KeywordTokenType.Translate:
             case KeywordTokenType.Extend:
@@ -566,6 +567,7 @@ const tokenTypeDefinitions: EnumToString<AllTokenTypes> = {
     Image: { name: "Image", value: KeywordTokenType.Image },
     LayeredImage: { name: "LayeredImage", value: KeywordTokenType.LayeredImage },
     Window: { name: "Window", value: KeywordTokenType.Window },
+    Frame: { name: "Frame", value: KeywordTokenType.Frame },
     Transform: { name: "Transform", value: KeywordTokenType.Transform },
     Translate: { name: "Translate", value: KeywordTokenType.Translate },
     Extend: { name: "Extend", value: KeywordTokenType.Extend },

--- a/src/tokenizer/renpy-tokens.ts
+++ b/src/tokenizer/renpy-tokens.ts
@@ -35,6 +35,7 @@ export const enum KeywordTokenType {
     Image,
     LayeredImage,
     Window,
+    Frame,
     Transform,
     Translate,
     Extend,

--- a/src/tokenizer/token-patterns.ts
+++ b/src/tokenizer/token-patterns.ts
@@ -366,7 +366,7 @@ const keywords: TokenPattern = {
         },
         {
             // Renpy keywords
-            match: /\b(?:(camera)|(image)|(label)|(layeredimage)|(menu)|(nvl[ \\t]+clear)|(play)|(queue)|(scene)|(screen)|(show)|(transform)|(translate)|(voice(?:[ \\t]+sustain)?)|(window))\b/dg,
+            match: /\b(?:(camera)|(image)|(label)|(layeredimage)|(menu)|(nvl[ \\t]+clear)|(play)|(queue)|(scene)|(screen)|(show)|(transform)|(translate)|(voice(?:[ \\t]+sustain)?)|(window)|(frame))\b/dg,
             captures: {
                 1: { token: KeywordTokenType.Camera },
                 2: { token: KeywordTokenType.Image },
@@ -383,6 +383,7 @@ const keywords: TokenPattern = {
                 13: { token: KeywordTokenType.Translate },
                 14: { token: KeywordTokenType.Voice },
                 15: { token: KeywordTokenType.Window },
+                16: { token: KeywordTokenType.Frame },
             },
         },
         {

--- a/syntaxes/renpy.python.tmLanguage.json
+++ b/syntaxes/renpy.python.tmLanguage.json
@@ -455,7 +455,7 @@
       ]
     },
     "string-unicode-guts": {
-      "patterns": [{ "include": "#escape-sequence-unicode" }, { "include": "#string-entity" }, { "include": "#string-brace-formatting" }]
+      "patterns": [{ "include": "source.renpy#strings-interior" }, { "include": "#escape-sequence-unicode" }, { "include": "#string-entity" }, { "include": "#string-brace-formatting" }]
     },
     "string-consume-escape": { "match": "\\\\['\"\\n\\\\]" },
     "string-raw-guts": {

--- a/syntaxes/renpy.tmLanguage.json
+++ b/syntaxes/renpy.tmLanguage.json
@@ -109,7 +109,7 @@
         { "include": "#with" },
         { "include": "#style-old" },
         { "include": "#use-old" },
-        { "include": "#screen-old" },
+        { "include": "#screen" },
         { "include": "#return-statements" },
         { "include": "#jump" },
         { "include": "#call" }
@@ -139,7 +139,7 @@
       "captures": {
         "1": { "name": "keyword.renpy" },
         "2": {
-          "name": "meta.with.params.renpy",
+          "name": "meta.at.params.renpy",
           "patterns": [{ "include": "#statements" }]
         }
       }
@@ -150,7 +150,7 @@
       "captures": {
         "1": { "name": "keyword.renpy" },
         "2": {
-          "name": "meta.with.params.renpy",
+          "name": "meta.as.params.renpy",
           "patterns": [{ "include": "#statements" }]
         }
       }
@@ -671,43 +671,168 @@
         "2": { "name": "entity.name.class.python.renpy.screen.renpy" }
       }
     },
-    "screen-old": {
-      "begin": "^\\s*(screen)\\s+(?=[A-Za-z_][A-Za-z0-9_]*\\s*\\()",
-      "beginCaptures": {
-        "1": { "name": "keyword.python.renpy" },
-        "2": { "name": "entity.name.class.python.renpy.screen.renpy" }
-      },
-      "end": "(\\))\\s*(?:(\\:)|(.*$\\n?))",
-      "endCaptures": {
-        "1": { "name": "punctuation.definition.parameters.end.python.renpy.screen.renpy" },
-        "2": { "name": "punctuation.section.function.begin.python.renpy.screen.renpy" },
-        "3": { "name": "invalid.illegal.missing-section-begin.python.renpy.screen.renpy" }
-      },
-      "name": "meta.function.python.renpy.screen.renpy",
+    "builtin-screens": {
+      "comment": "TODO: Should combine this with builtin-labels",
+      "name": "support.function.builtin.renpy",
+      "match": "(?<!\\.)\\b(?:start|quit|after_load|splashscreen|before_main_menu|main_menu|after_warp|hide_windows)\\b"
+    },
+    "screen-def-name": {
+      "comment": "TODO: Should combine this with label-def-name",
+      "patterns": [
+        { "include": "source.renpy.python#builtin-possible-callables" },
+        { "include": "#builtin-screens" },
+        {
+          "match": "(?<=^|[ \\t])(\\b(?:[a-zA-Z_]\\w*)\\b)?(\\.)?(\\b(?:[a-zA-Z_]\\w*)\\b)",
+          "captures": {
+            "1": { "name": "entity.name.function.renpy" },
+            "2": { "name": "punctuation.separator.period.renpy" },
+            "3": { "name": "entity.name.function.renpy" }
+          }
+        }
+      ]
+    },
+    "screen-simple-expression": {
+      "patterns": [
+        { "include": "#expressions" },
+        { "include": "source.renpy.python#literal" },
+        { "include": "source.renpy.python#member-access" },
+        { "include": "source.renpy.python#illegal-operator" },
+        { "include": "source.renpy.python#operator" },
+        { "include": "source.renpy.python#curly-braces" },
+        { "include": "source.renpy.python#item-access" },
+        { "include": "source.renpy.python#list" },
+        { "include": "source.renpy.python#odd-function-call" },
+        { "include": "source.renpy.python#round-braces" },
+        { "include": "source.renpy.python#function-call" },
+        { "include": "source.renpy.python#builtin-functions" },
+        { "include": "source.renpy.python#builtin-types" },
+        { "include": "source.renpy.python#builtin-exceptions" },
+        { "include": "source.renpy.python#magic-names" },
+        { "include": "source.renpy.python#special-names" },
+        { "include": "source.renpy.python#illegal-names" },
+        { "include": "source.renpy.python#special-variables" },
+        { "include": "source.renpy.python#ellipsis" },
+        { "include": "source.renpy.python#punctuation" },
+        { "include": "source.renpy.python#line-continuation" }
+      ]
+    },
+    "screen-keywords": {
+      "comment": "https://www.renpy.org/doc/html/screens.html#screen-statement",
       "patterns": [
         {
-          "begin": "(?=[A-Za-z_][A-Za-z0-9_]*)",
-          "contentName": "entity.name.function.python.renpy.screen.renpy",
-          "end": "(?![A-Za-z0-9_])",
-          "patterns": [{ "include": "#entity_name_function" }]
+          "contentName": "meta.screen.sensitive.renpy",
+          "begin": "^[ \\t]*(sensitive)\\b[ \\t]*",
+          "beginCaptures": {
+            "1": { "name": "keyword.renpy" }
+          },
+          "end": "$",
+          "patterns": [{ "include": "#screen-simple-expression" }]
         },
         {
-          "begin": "(\\()",
+          "name": "keyword.renpy",
+          "match": "\\b(?<!\\.)(?:modal|sensitive|tag|zorder|variant|layer|roll_forward|text)\\b"
+        },
+        {
+          "name": "keyword.renpy",
+          "match": "\\b(?<!\\.)(?:style|style_group|style_prefix)\\b"
+        },
+        {
+          "name": "keyword.renpy",
+          "match": "\\b(?<!\\.)(?:has|vbox|label|add|xfill)\\b"
+        }
+      ]
+    },
+    "screen-frame": {
+      "contentName": "meta.screen.frame.renpy",
+      "begin": "^([ \\t]+)?(frame)\\b[ \\t]*(:)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.whitespace.leading.block.renpy" },
+        "2": { "name": "keyword.other.renpy" },
+        "3": { "name": "punctuation.section.block.begin.renpy" }
+      },
+      "end": "^(?=(?!\\1)[ \\t]*[^\\s#]|\\1[^\\s#])",
+      "patterns": [{ "include": "#screen-language" }]
+    },
+    "screen-window": {
+      "contentName": "meta.screen.window.renpy",
+      "begin": "^([ \\t]+)?(window)\\b[ \\t]*(:)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.whitespace.leading.block.renpy" },
+        "2": { "name": "keyword.other.renpy" },
+        "3": { "name": "punctuation.section.block.begin.renpy" }
+      },
+      "end": "^(?=(?!\\1)[ \\t]*[^\\s#]|\\1[^\\s#])",
+      "patterns": [{ "include": "#screen-language" }]
+    },
+    "screen-text": {
+      "contentName": "meta.screen.text.renpy",
+      "begin": "^([ \\t]+)?(text)\\b[ \\t]*(:)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.whitespace.leading.block.renpy" },
+        "2": { "name": "keyword.other.renpy" },
+        "3": { "name": "punctuation.section.block.begin.renpy" }
+      },
+      "end": "^(?=(?!\\1)[ \\t]*[^\\s#]|\\1[^\\s#])",
+
+      "patterns": [
+        {
+          "name": "meta.screen.text.renpy",
+          "contentName": "meta.screen.text.atl-block.renpy",
+          "begin": "^([ \\t]+)?(text)\\b[ \\t]*([a-zA-Z_0-9 ]*)(:)",
           "beginCaptures": {
-            "1": { "name": "punctuation.definition.parameters.begin.python.renpy.screen.renpy" }
+            "1": { "name": "punctuation.whitespace.leading.renpy" },
+            "2": { "name": "keyword.renpy" },
+            "3": { "name": "entity.name.type.text.renpy" },
+            "4": { "name": "punctuation.section.atl.begin.renpy" }
           },
-          "contentName": "meta.function.parameters.python.renpy.screen.renpy",
-          "end": "(?=\\)\\s*\\:)",
+          "end": "^(?=(?!\\1)[ \\t]*[^\\s#]|\\1[^\\s#])",
+          "patterns": [{ "include": "#atl" }]
+        },
+        {
+          "name": "meta.screen.text.renpy",
+          "begin": "^[ \\t]*(text)\\b[ \\t]*",
+          "beginCaptures": {
+            "1": { "name": "keyword.renpy" }
+          },
+          "end": "(?!\\G)(?=\\b(at)\\b|#|=)|$",
           "patterns": [
-            { "include": "#keyword_arguments" },
+            { "include": "#strings" },
             {
-              "captures": {
-                "1": { "name": "variable.parameter.function.python.renpy.screen.renpy" },
-                "2": { "name": "punctuation.separator.parameters.python.renpy.screen.renpy" }
-              },
-              "match": "\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)]))"
+              "match": "\\b(?:[a-zA-Z_0-9]+)\\b[ \\t]*",
+              "name": "entity.name.type.text.renpy"
             }
           ]
+        },
+        { "include": "#at" }
+      ]
+    },
+    "screen-language": {
+      "comment": "https://www.renpy.org/doc/html/screens.html#screen-language",
+      "patterns": [{ "include": "#screen-frame" }, { "include": "#screen-window" }, { "include": "#screen-text" }, { "include": "#screen-keywords" }, { "include": "#screen-simple-expression" }]
+    },
+    "screen": {
+      "patterns": [
+        {
+          "comment": "See https://www.renpy.org/doc/html/screens.html",
+          "contentName": "meta.screen.block.renpy",
+          "begin": "^([ \\t]+)?(screen)\\b[ \\t]*(.*?)(:)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.whitespace.leading.block.renpy" },
+            "2": { "name": "storage.type.function.renpy" },
+            "3": {
+              "patterns": [
+                { "include": "#screen-def-name" },
+                { "include": "source.renpy.python#parameters" },
+                {
+                  "match": ".*",
+                  "name": "invalid.illegal.name.renpy"
+                }
+              ]
+            },
+            "4": { "name": "punctuation.section.block.begin.renpy" }
+          },
+          "end": "^(?=(?!\\1)[ \\t]*[^\\s#]|\\1[^\\s#])",
+          "patterns": [{ "include": "#screen-language" }]
         }
       ]
     },
@@ -1101,7 +1226,7 @@
         },
         {
           "comment": "Renpy keywords",
-          "match": "\\b(?<!\\.)(?:camera|image|label|layeredimage|menu|nvl[ \\t]+clear|play|queue|scene|screen|show|transform|translate|voice(?:[ \\t]+sustain)?|window)\\b",
+          "match": "\\b(?<!\\.)(?:camera|image|label|layeredimage|menu|nvl[ \\t]+clear|play|queue|scene|screen|show|transform|translate|voice(?:[ \\t]+sustain)?|window|frame)\\b",
           "name": "keyword.other.renpy"
         },
         {


### PR DESCRIPTION
* Allow renpy string tags to be displayed in 'normal' python strings
* Adds a (minimal) implementation of the screen languague. (Currently it's mainly for the purpose of keeping screen languague syntax seperate)