### PR TITLE
Chore(Enhancement) - Add a command that cleans up compiled files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
       },
       {
         "command": "renpy.migrateOldFiles",
-        "title": "Cleanup unused compiled Ren'Py source files"
+        "title": "Renpy: Cleanup unused compiled Ren'Py source files"
       },
       {
         "command": "renpy.runCommand",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         "title": "Refresh Ren'Py diagnostics for the active editor window"
       },
       {
+        "command": "renpy.migrateOldFiles",
+        "title": "Cleanup unused compiled Ren'Py source files"
+      },
+      {
         "command": "renpy.runCommand",
         "title": "Run Project",
         "category": "Run",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import {
     window,
     workspace,
     WorkspaceConfiguration,
+    RelativePattern,
 } from "vscode";
 import { RenpyColorProvider } from "./color";
 import { getCompletionList } from "./completion";
@@ -251,7 +252,34 @@ export async function activate(context: ExtensionContext): Promise<any> {
     });
     context.subscriptions.push(gotoFileLocationCommand);
 
-    // custom command - refresh diagnositcs
+    const migrateOldFilesCommand = commands.registerCommand("renpy.migrateOldFiles", () => {
+        if (workspace !== null) {
+            workspace.findFiles("**/*.rpyc", null, 50).then((uris: Uri[]) => {
+                uris.forEach((uri) => {
+                    const sourceFile = Uri.parse(uri.toString().replace(".rpyc", ".rpy"));
+                    workspace.fs.stat(sourceFile).then(
+                        function () {
+                            // Do nothing
+                        },
+                        function () {
+                            const endOfPath = uri.toString().replace("game", "old-game").lastIndexOf("/");
+                            const properLocation = Uri.parse(uri.toString().replace("game", "old-game"));
+                            const oldDataDirectory = Uri.parse(properLocation.toString().substring(0, endOfPath));
+                            workspace.fs.createDirectory(oldDataDirectory);
+                            workspace.fs
+                                .readFile(uri)
+                                .then((data) => workspace.fs.writeFile(properLocation, data))
+                                .then(() => workspace.fs.delete(uri));
+                        }
+                    );
+                });
+            });
+        }
+    });
+
+    context.subscriptions.push(migrateOldFilesCommand);
+
+    // custom command - refresh diagnostics
     const refreshDiagnosticsCommand = commands.registerCommand("renpy.refreshDiagnostics", () => {
         if (window.activeTextEditor) {
             refreshDiagnostics(window.activeTextEditor.document, diagnostics);
@@ -261,7 +289,7 @@ export async function activate(context: ExtensionContext): Promise<any> {
 
     // custom command - call renpy to run workspace
     const runCommand = commands.registerCommand("renpy.runCommand", () => {
-        //EsLint reccommends config be removed as it has already been decrlaed in a previous scope
+        //EsLint recommends config be removed as it has already been declared in a previous scope
         if (!config || !isValidExecutable(config.renpyExecutableLocation)) {
             window.showErrorMessage("Ren'Py executable location not configured or is invalid.");
         } else {
@@ -455,6 +483,7 @@ function RunWorkspaceFolder(): boolean {
             }
             return true;
         }
+        return false;
     } else {
         console.log("config for rennpy does not exist");
         return false;


### PR DESCRIPTION
## Description
It cleans up a few minor misspellings and properly adds a command to move all compiled files that don't have source files to the old-game directory. The command heading is "renpy.migrateOldFiles" and the formal title is "Cleanup unused compiled Ren'Py source files" 

## Related Issue

Closes #144
