### PR TITLE
Support syntax highlighting in _ren.py files

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,7 @@ name: PR Check
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, edited]
     branches:
       - master
       - develop

--- a/examples/test_ren.py
+++ b/examples/test_ren.py
@@ -1,0 +1,17 @@
+# This is not included in the game. It's here so that an editor knows
+# the type of strength.
+strength = 100
+
+"""renpy
+init python:
+"""
+
+class BoostStrength(Action):
+    """
+    Boosts the strength of the player by 10.
+    """
+
+    def __call__(self):
+        global strength
+        strength += 10
+        renpy.restart_interaction()

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "activationEvents": [
     "onLanguage:renpy",
-    "workspaceContains:**/*.rpy"
+    "workspaceContains:**/*.rpy",
+    "workspaceContains:**/_ren.py"
   ],
   "main": "./dist/extension",
   "browser": "./dist/extension.js",
@@ -46,7 +47,8 @@
         "id": "renpy",
         "aliases": [
           "Ren'Py",
-          "renpy"
+          "renpy",
+          "rpy"
         ],
         "extensions": [
           ".rpy",
@@ -87,6 +89,16 @@
       {
         "scopeName": "source.renpy.python",
         "path": "./syntaxes/renpy.python.tmLanguage.json"
+      },
+      {
+        "scopeName": "renpy.comment.injection",
+        "path": "./syntaxes/injection.json",
+        "injectTo": [
+          "source.python"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.renpy": "renpy"
+        }
       },
       {
         "language": "renpy-log",

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -1,0 +1,26 @@
+{
+  "scopeName": "renpy.comment.injection",
+  "injectionSelector": "L:string.quoted.docstring",
+  "patterns": [
+    {
+      "include": "#renpy-source"
+    }
+  ],
+  "repository": {
+    "renpy-source": {
+      "contentName": "meta.embedded.renpy",
+      "begin": "(?<=^\\\"\\\"\\\")renpy",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.renpy"
+        }
+      },
+      "end": "(?=^\\\"\\\"\\\")",
+      "patterns": [
+        {
+          "include": "source.renpy"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add injection grammar for renpy comments in _ren.py files

For now this will only work in doc strings, python syntax highlighting isn't changed