### PR TITLE
Fix crash on function signature help

### DIFF
--- a/src/signature.ts
+++ b/src/signature.ts
@@ -36,7 +36,7 @@ export function getSignatureHelp(document: TextDocument, position: Position, con
     const currentLine = document.lineAt(position.line).text;
     const currentLinePrefix = currentLine.substring(0, position.character);
     const openParenthesis = currentLinePrefix.lastIndexOf("(");
-    if (openParenthesis) {
+    if (openParenthesis >= 0) {
         const prevPosition = new Position(position.line, openParenthesis - 1);
         const prevRange = document.getWordRangeAtPosition(prevPosition);
         if (!prevRange) {


### PR DESCRIPTION
openParenthesis could be -1 when this is triggered while removing the parens